### PR TITLE
Adding ability to select port for launch control setup.

### DIFF
--- a/src/ofxLaunchControl.cpp
+++ b/src/ofxLaunchControl.cpp
@@ -36,8 +36,7 @@ ofxLaunchControl::ofxLaunchControl(){
 
 }
 
-void ofxLaunchControl::setup(  ){
-	int id = -1;
+void ofxLaunchControl::setup( int id, int channel ){
 	const auto & ports = midiIn.getInPortList();
 	string target = "Launch Control";
 	for( size_t i=0; i<ports.size(); ++i){
@@ -54,7 +53,7 @@ void ofxLaunchControl::setup(  ){
 		}
 	}
 	if(id>=0){
-		ofxControllerBase::setup( id );
+		ofxControllerBase::setup( id, channel );
 	}else{
 		ofLogError()<<"ofxLaunchControls: automatic setup error, Launch Control not found";
 	}

--- a/src/ofxLaunchControl.cpp
+++ b/src/ofxLaunchControl.cpp
@@ -38,17 +38,19 @@ ofxLaunchControl::ofxLaunchControl(){
 
 void ofxLaunchControl::setup( int id, int channel ){
 	const auto & ports = midiIn.getInPortList();
-	string target = "Launch Control";
-	for( size_t i=0; i<ports.size(); ++i){
-		string cut = ports[i].substr(0, target.length());
-		if( target.compare(cut)==0 ){
+	if (id==-1){
+		string target = "Launch Control";
+		for( size_t i=0; i<ports.size(); ++i){
+			string cut = ports[i].substr(0, target.length());
+			if( target.compare(cut)==0 ){
 
-			// now check that isn't the launch control xl
-			string xl = "Launch Control XL";
-			string recut = ports[i].substr(0, xl.length());
-			if( xl.compare(recut)!=0 ){
-				id = i;
-				break;
+				// now check that isn't the launch control xl
+				string xl = "Launch Control XL";
+				string recut = ports[i].substr(0, xl.length());
+				if( xl.compare(recut)!=0 ){
+					id = i;
+					break;
+				}
 			}
 		}
 	}

--- a/src/ofxLaunchControl.h
+++ b/src/ofxLaunchControl.h
@@ -6,5 +6,5 @@
 class ofxLaunchControl : public ofxControllerBase {
 public:
 	ofxLaunchControl();
-	void setup();
+	void setup( int id=-1, int channel=9 );
 };


### PR DESCRIPTION
I ran into the problem of having my device name not match the target.

```
[notice ] ofxMidiIn: 1 ports available
[notice ] ofxMidiIn: 0: 2- Launch Control 0
[ error ] ofxLaunchControls: automatic setup error, Launch Control not found
```

The setup function from ofxControllerBase wasn't inherited because it's not a virtual method and it was overridden. So there's no easy way of manually setting the port.

This is the fix I made and seems to work great for me with the example. Also added in an if statement so someone could theoretically use 2 launch controls at the same time. Might be checking worth the XL code I think it would have the same problem.

P.S. Thanks for the library! Will definitely send you a couple bucks on ko-fi if I end up using it in my project.